### PR TITLE
feat FunctionCallerName

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"log/syslog"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 )
 
@@ -54,6 +57,8 @@ func SetLogLevel(level int) {
 }
 
 func logAtLevel(debugLevel int, format string, params ...interface{}) {
+	functionCaller := funcName() + ": "
+	format = functionCaller + format
 	if loggerRunning && debugLevel >= loggerLevel {
 		if len(params) > 0 {
 			logTypes[debugLevel].Channel <- fmt.Sprintf(format, params...)
@@ -190,4 +195,12 @@ func logInfo(msg string) {
 
 func logWarn(msg string) {
 	log.Printf("WARN: %s\n", msg)
+}
+
+func funcName() string {
+	pc, _, _, _ := runtime.Caller(3)
+	nameFull := runtime.FuncForPC(pc).Name()
+	nameEnd := filepath.Ext(nameFull)        // .foo
+	name := strings.TrimPrefix(nameEnd, ".") // foo
+	return name
 }

--- a/logger.go
+++ b/logger.go
@@ -57,8 +57,7 @@ func SetLogLevel(level int) {
 }
 
 func logAtLevel(debugLevel int, format string, params ...interface{}) {
-	functionCaller := funcName() + ": "
-	format = functionCaller + format
+	format = funcName() + format
 	if loggerRunning && debugLevel >= loggerLevel {
 		if len(params) > 0 {
 			logTypes[debugLevel].Channel <- fmt.Sprintf(format, params...)
@@ -198,9 +197,13 @@ func logWarn(msg string) {
 }
 
 func funcName() string {
-	pc, _, _, _ := runtime.Caller(3)
-	nameFull := runtime.FuncForPC(pc).Name()
-	nameEnd := filepath.Ext(nameFull)        // .foo
-	name := strings.TrimPrefix(nameEnd, ".") // foo
-	return name
+	pc, _, _, ok := runtime.Caller(3)
+	if ok {
+		funcPtr := runtime.FuncForPC(pc)
+		if funcPtr != nil {
+			nameEnd := filepath.Ext(funcPtr.Name())
+			return strings.TrimPrefix(nameEnd, ".") + ": "
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
 Add caller function name on logs

![image](https://cloud.githubusercontent.com/assets/16577878/24311832/9bcf3fa2-10b4-11e7-9744-925e3594e5b2.png)

The name of each method is added automatically before the text message when logger.[Error|Debug|...] is called.